### PR TITLE
[Bug fix] Index out of bounds in builder.rs

### DIFF
--- a/tests/expected_tyvcd/mod.rs
+++ b/tests/expected_tyvcd/mod.rs
@@ -1,3 +1,4 @@
 pub mod bar;
 pub mod foo;
 pub mod with_bundles_and_vecs;
+pub mod vec_test;

--- a/tests/expected_tyvcd/vec_test.rs
+++ b/tests/expected_tyvcd/vec_test.rs
@@ -1,0 +1,502 @@
+use crate::tyvcd::spec::*;
+use crate::HashMap;
+use crate::TraceValue;
+use std::sync::{Arc, RwLock};
+
+pub fn create_vecs() -> TyVcd {
+    let mut scopes = HashMap::new();
+    // Main scope
+    scopes.insert(
+        String::from("Issue10"),
+        Arc::new(RwLock::new(Scope::empty(
+            String::from("Issue10"),
+            String::from("Issue10"),
+            TypeInfo::new("Issue10".to_string(), vec![]),
+        ))),
+    );
+
+    // clock
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(Variable::new(
+            TraceValue::RefTraceName("clock".to_string()),
+            String::from("clock"),
+            TypeInfo::new("IO[Clock]".to_string(), Vec::new()),
+            VariableKind::Ground(1),
+        ));
+
+    // reset
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(Variable::new(
+            TraceValue::RefTraceName("reset".to_string()),
+            String::from("reset"),
+            TypeInfo::new("IO[Bool]".to_string(), Vec::new()),
+            VariableKind::Ground(1),
+        ));
+
+    // vec1
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(create_vec1());
+    // vec2
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(create_vec2());
+    // vec3
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(create_vec3());
+    // vec4
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(create_vec4());
+    // vec5
+    scopes
+        .get("Issue10")
+        .unwrap()
+        .write()
+        .unwrap()
+        .variables
+        .push(create_vec5());
+    TyVcd { scopes }
+}
+
+fn create_vec1() -> Variable {
+    let vec1_0_x = TraceValue::RefTraceName("vec1_0_x_0".to_string());
+    let vec1_0_x = TraceValue::RefTraceName("vec1_0_x_0".to_string());
+    let vec1_0 = TraceValue::RefTraceValues(vec![vec1_0_x.clone()]);
+    let vec1_1_x = TraceValue::RefTraceName("vec1_1_x_0".to_string());
+    let vec1_1 = TraceValue::RefTraceValues(vec![vec1_1_x.clone()]);
+    let vec1 = TraceValue::RefTraceValues(vec![vec1_0.clone(), vec1_1.clone()]);
+
+    Variable::new(
+        vec1,
+        String::from("vec1"),
+        TypeInfo::new("IO[VecType1[2]]".to_string(), vec![]),
+        VariableKind::Vector {
+            fields: vec![
+                // vec1[0]
+                Variable::new(
+                    vec1_0,
+                    String::from("0"),
+                    TypeInfo::new("IO[VecType1[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![Variable::new(
+                            vec1_0_x,
+                            String::from("x"),
+                            TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                            VariableKind::Ground(1),
+                        )],
+                    },
+                ),
+                // vec1[1]
+                Variable::new(
+                    vec1_1,
+                    String::from("1"),
+                    TypeInfo::new("IO[VecType1[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![Variable::new(
+                            vec1_1_x,
+                            String::from("x"),
+                            TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                            VariableKind::Ground(1),
+                        )],
+                    },
+                ),
+            ],
+        },
+    )
+}
+
+fn create_vec2() -> Variable {
+    let vec2_0_x = TraceValue::RefTraceName("vec2_0_x_0".to_string());
+    let vec2_0_y = TraceValue::RefTraceName("vec2_0_y_0".to_string());
+    let vec2_0 = TraceValue::RefTraceValues(vec![vec2_0_x.clone(), vec2_0_y.clone()]);
+    let vec2_1_x = TraceValue::RefTraceName("vec2_1_x_0".to_string());
+    let vec2_1_y = TraceValue::RefTraceName("vec2_1_y_0".to_string());
+    let vec2_1 = TraceValue::RefTraceValues(vec![vec2_1_x.clone(), vec2_1_y.clone()]);
+    let vec2 = TraceValue::RefTraceValues(vec![vec2_0.clone(), vec2_1.clone()]);
+
+    Variable::new(
+        vec2,
+        String::from("vec2"),
+        TypeInfo::new("IO[VecType2[2]]".to_string(), vec![]),
+        VariableKind::Vector {
+            fields: vec![
+                // vec2[0]
+                Variable::new(
+                    vec2_0,
+                    String::from("0"),
+                    TypeInfo::new("IO[VecType2[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec2_0_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec2_0_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                        ],
+                    },
+                ),
+                // vec1[1]
+                Variable::new(
+                    vec2_1,
+                    String::from("1"),
+                    TypeInfo::new("IO[VecType2[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec2_1_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec2_1_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                        ],
+                    },
+                ),
+            ],
+        },
+    )
+}
+
+fn create_vec3() -> Variable {
+    let vec3_0_x = TraceValue::RefTraceName("vec3_0_x_0".to_string());
+    let vec3_0_y = TraceValue::RefTraceName("vec3_0_y_0".to_string());
+    let vec3_0_z = TraceValue::RefTraceName("vec3_0_z_0".to_string());
+    let vec3_0 =
+        TraceValue::RefTraceValues(vec![vec3_0_x.clone(), vec3_0_y.clone(), vec3_0_z.clone()]);
+    let vec3_1_x = TraceValue::RefTraceName("vec3_1_x_0".to_string());
+    let vec3_1_y = TraceValue::RefTraceName("vec3_1_y_0".to_string());
+    let vec3_1_z = TraceValue::RefTraceName("vec3_1_z_0".to_string());
+    let vec3_1 =
+        TraceValue::RefTraceValues(vec![vec3_1_x.clone(), vec3_1_y.clone(), vec3_1_z.clone()]);
+    let vec3 = TraceValue::RefTraceValues(vec![vec3_0.clone(), vec3_1.clone()]);
+
+    Variable::new(
+        vec3,
+        String::from("vec3"),
+        TypeInfo::new("IO[VecType3[2]]".to_string(), vec![]),
+        VariableKind::Vector {
+            fields: vec![
+                // vec3[0]
+                Variable::new(
+                    vec3_0,
+                    String::from("0"),
+                    TypeInfo::new("IO[VecType3[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec3_0_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec3_0_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                            Variable::new(
+                                vec3_0_z,
+                                String::from("z"),
+                                TypeInfo::new("IO[UInt<3>]".to_string(), vec![]),
+                                VariableKind::Ground(3),
+                            ),
+                        ],
+                    },
+                ),
+                // vec1[1]
+                Variable::new(
+                    vec3_1,
+                    String::from("1"),
+                    TypeInfo::new("IO[VecType3[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec3_1_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec3_1_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                            Variable::new(
+                                vec3_1_z,
+                                String::from("z"),
+                                TypeInfo::new("IO[UInt<3>]".to_string(), vec![]),
+                                VariableKind::Ground(3),
+                            ),
+                        ],
+                    },
+                ),
+            ],
+        },
+    )
+}
+
+fn create_vec4() -> Variable {
+    let vec4_0_x = TraceValue::RefTraceName("vec4_0_x_0".to_string());
+    let vec4_0_y = TraceValue::RefTraceName("vec4_0_y_0".to_string());
+    let vec4_0_z = TraceValue::RefTraceName("vec4_0_z_0".to_string());
+    let vec4_0_w = TraceValue::RefTraceName("vec4_0_w_0".to_string());
+    let vec4_0 = TraceValue::RefTraceValues(vec![
+        vec4_0_x.clone(),
+        vec4_0_y.clone(),
+        vec4_0_z.clone(),
+        vec4_0_w.clone(),
+    ]);
+    let vec4_1_x = TraceValue::RefTraceName("vec4_1_x_0".to_string());
+    let vec4_1_y = TraceValue::RefTraceName("vec4_1_y_0".to_string());
+    let vec4_1_z = TraceValue::RefTraceName("vec4_1_z_0".to_string());
+    let vec4_1_w = TraceValue::RefTraceName("vec4_1_w_0".to_string());
+    let vec4_1 = TraceValue::RefTraceValues(vec![
+        vec4_1_x.clone(),
+        vec4_1_y.clone(),
+        vec4_1_z.clone(),
+        vec4_1_w.clone(),
+    ]);
+    let vec4 = TraceValue::RefTraceValues(vec![vec4_0.clone(), vec4_1.clone()]);
+
+    Variable::new(
+        vec4,
+        String::from("vec4"),
+        TypeInfo::new("IO[VecType4[2]]".to_string(), vec![]),
+        VariableKind::Vector {
+            fields: vec![
+                // vec4[0]
+                Variable::new(
+                    vec4_0,
+                    String::from("0"),
+                    TypeInfo::new("IO[VecType4[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec4_0_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec4_0_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                            Variable::new(
+                                vec4_0_z,
+                                String::from("z"),
+                                TypeInfo::new("IO[UInt<3>]".to_string(), vec![]),
+                                VariableKind::Ground(3),
+                            ),
+                            Variable::new(
+                                vec4_0_w,
+                                String::from("w"),
+                                TypeInfo::new("IO[UInt<4>]".to_string(), vec![]),
+                                VariableKind::Ground(4),
+                            ),
+                        ],
+                    },
+                ),
+                // vec1[1]
+                Variable::new(
+                    vec4_1,
+                    String::from("1"),
+                    TypeInfo::new("IO[VecType4[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec4_1_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec4_1_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                VariableKind::Ground(2),
+                            ),
+                            Variable::new(
+                                vec4_1_z,
+                                String::from("z"),
+                                TypeInfo::new("IO[UInt<3>]".to_string(), vec![]),
+                                VariableKind::Ground(3),
+                            ),
+                            Variable::new(
+                                vec4_1_w,
+                                String::from("w"),
+                                TypeInfo::new("IO[UInt<4>]".to_string(), vec![]),
+                                VariableKind::Ground(4),
+                            ),
+                        ],
+                    },
+                ),
+            ],
+        },
+    )
+}
+
+fn create_vec5() -> Variable {
+    let vec5_0_x = TraceValue::RefTraceName("vec5_0_x_0".to_string());
+    let vec5_0_y_a_0 = TraceValue::RefTraceName("vec5_0_y_a_0".to_string());
+    let vec5_0_y_b_0 = TraceValue::RefTraceName("vec5_0_y_b_0".to_string());
+    let vec5_0_y_c_0 = TraceValue::RefTraceName("vec5_0_y_c_0".to_string());
+    let vec5_0_y = TraceValue::RefTraceValues(vec![
+        vec5_0_y_a_0.clone(),
+        vec5_0_y_b_0.clone(),
+        vec5_0_y_c_0.clone(),
+    ]);
+    let vec5_0 = TraceValue::RefTraceValues(vec![vec5_0_x.clone(), vec5_0_y.clone()]);
+
+    let vec5_1_x = TraceValue::RefTraceName("vec5_1_x_0".to_string());
+    let vec5_1_y_a_0 = TraceValue::RefTraceName("vec5_1_y_a_0".to_string());
+    let vec5_1_y_b_0 = TraceValue::RefTraceName("vec5_1_y_b_0".to_string());
+    let vec5_1_y_c_0 = TraceValue::RefTraceName("vec5_1_y_c_0".to_string());
+    let vec5_1_y = TraceValue::RefTraceValues(vec![
+        vec5_1_y_a_0.clone(),
+        vec5_1_y_b_0.clone(),
+        vec5_1_y_c_0.clone(),
+    ]);
+    let vec5_1 = TraceValue::RefTraceValues(vec![vec5_1_x.clone(), vec5_1_y.clone()]);
+
+    let vec5 = TraceValue::RefTraceValues(vec![vec5_0.clone(), vec5_1.clone()]);
+
+    Variable::new(
+        vec5,
+        String::from("vec5"),
+        TypeInfo::new("IO[VecType5[2]]".to_string(), vec![]),
+        VariableKind::Vector {
+            fields: vec![
+                // vec5[0]
+                Variable::new(
+                    vec5_0,
+                    String::from("0"),
+                    TypeInfo::new("IO[VecType5[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec5_0_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec5_0_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[AnonymousBundle]".to_string(), vec![]),
+                                VariableKind::Struct {
+                                    fields: vec![
+                                        Variable::new(
+                                            vec5_0_y_a_0,
+                                            String::from("a"),
+                                            TypeInfo::new("IO[UInt<32>]".to_string(), vec![]),
+                                            VariableKind::Ground(32),
+                                        ),
+                                        Variable::new(
+                                            vec5_0_y_b_0,
+                                            String::from("b"),
+                                            TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                            VariableKind::Ground(2),
+                                        ),
+                                        Variable::new(
+                                            vec5_0_y_c_0,
+                                            String::from("c"),
+                                            TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                            VariableKind::Ground(2),
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+                // vec1[1]
+                Variable::new(
+                    vec5_1,
+                    String::from("1"),
+                    TypeInfo::new("IO[VecType5[2]]".to_string(), vec![]),
+                    VariableKind::Struct {
+                        fields: vec![
+                            Variable::new(
+                                vec5_1_x,
+                                String::from("x"),
+                                TypeInfo::new("IO[UInt<1>]".to_string(), vec![]),
+                                VariableKind::Ground(1),
+                            ),
+                            Variable::new(
+                                vec5_1_y,
+                                String::from("y"),
+                                TypeInfo::new("IO[AnonymousBundle]".to_string(), vec![]),
+                                VariableKind::Struct {
+                                    fields: vec![
+                                        Variable::new(
+                                            vec5_1_y_a_0,
+                                            String::from("a"),
+                                            TypeInfo::new("IO[UInt<32>]".to_string(), vec![]),
+                                            VariableKind::Ground(32),
+                                        ),
+                                        Variable::new(
+                                            vec5_1_y_b_0,
+                                            String::from("b"),
+                                            TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                            VariableKind::Ground(2),
+                                        ),
+                                        Variable::new(
+                                            vec5_1_y_c_0,
+                                            String::from("c"),
+                                            TypeInfo::new("IO[UInt<2>]".to_string(), vec![]),
+                                            VariableKind::Ground(2),
+                                        ),
+                                    ],
+                                },
+                            ),
+                        ],
+                    },
+                ),
+            ],
+        },
+    )
+}

--- a/tests/inputs/tyvcd/vecTest.dd
+++ b/tests/inputs/tyvcd/vecTest.dd
@@ -1,0 +1,805 @@
+{
+    "HGLDD": {
+      "version": "1.0",
+      "file_info": []
+    },
+    "objects": [
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 84,
+          "end_column": 16,
+          "end_line": 84,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec1",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 84,
+              "end_column": 16,
+              "end_line": 84,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 84,
+          "end_column": 16,
+          "end_line": 84,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec1_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 84,
+              "end_column": 16,
+              "end_line": 84,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 85,
+          "end_column": 16,
+          "end_line": 85,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec2",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 85,
+              "end_column": 16,
+              "end_line": 85,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 85,
+              "end_column": 16,
+              "end_line": 85,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 85,
+          "end_column": 16,
+          "end_line": 85,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec2_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 85,
+              "end_column": 16,
+              "end_line": 85,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 85,
+              "end_column": 16,
+              "end_line": 85,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 86,
+          "end_column": 16,
+          "end_line": 86,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec3",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "packed_range": [
+              2,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<3>]"
+            },
+            "type_name": "logic",
+            "var_name": "z"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 86,
+          "end_column": 16,
+          "end_line": 86,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec3_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "packed_range": [
+              2,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<3>]"
+            },
+            "type_name": "logic",
+            "var_name": "z"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 87,
+          "end_column": 16,
+          "end_line": 87,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec4",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              2,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<3>]"
+            },
+            "type_name": "logic",
+            "var_name": "z"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              3,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<4>]"
+            },
+            "type_name": "logic",
+            "var_name": "w"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 87,
+          "end_column": 16,
+          "end_line": 87,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec4_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "y"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              2,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<3>]"
+            },
+            "type_name": "logic",
+            "var_name": "z"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "packed_range": [
+              3,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<4>]"
+            },
+            "type_name": "logic",
+            "var_name": "w"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 88,
+          "end_column": 16,
+          "end_line": 88,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec5_y",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              31,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<32>]"
+            },
+            "type_name": "logic",
+            "var_name": "a"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "b"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "c"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 88,
+          "end_column": 16,
+          "end_line": 88,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec5",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[AnonymousBundle]"
+            },
+            "type_name": "Issue10_vec5_y",
+            "var_name": "y"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 88,
+          "end_column": 16,
+          "end_line": 88,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec5_y_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              31,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<32>]"
+            },
+            "type_name": "logic",
+            "var_name": "a"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "b"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "packed_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<2>]"
+            },
+            "type_name": "logic",
+            "var_name": "c"
+          }
+        ]
+      },
+      {
+        "hgl_loc": {
+          "begin_column": 16,
+          "begin_line": 88,
+          "end_column": 16,
+          "end_line": 88,
+          "file": 1
+        },
+        "kind": "struct",
+        "obj_name": "Issue10_vec5_0",
+        "port_vars": [
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[UInt<1>]"
+            },
+            "type_name": "logic",
+            "var_name": "x"
+          },
+          {
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "source_lang_type_info": {
+              "type_name": "IO[AnonymousBundle]"
+            },
+            "type_name": "Issue10_vec5_y_0",
+            "var_name": "y"
+          }
+        ]
+      },
+      {
+        "kind": "module",
+        "obj_name": "Issue10",
+        "module_name": "Issue10",
+        "hgl_loc": {
+          "begin_column": 7,
+          "begin_line": 83,
+          "end_column": 7,
+          "end_line": 83,
+          "file": 1
+        },
+        "hdl_loc": {
+          "begin_line": 2,
+          "end_line": 2,
+          "file": 2
+        },
+        "source_lang_type_info": {
+          "type_name": "Issue10"
+        },
+        "port_vars": [
+          {
+            "var_name": "clock",
+            "hgl_loc": {
+              "begin_column": 7,
+              "begin_line": 83,
+              "end_column": 7,
+              "end_line": 83,
+              "file": 1
+            },
+            "value": {"sig_name":"clock"},
+            "type_name": "logic",
+            "source_lang_type_info": {
+              "type_name": "IO[Clock]"
+            }
+          },
+          {
+            "var_name": "reset",
+            "hgl_loc": {
+              "begin_column": 7,
+              "begin_line": 83,
+              "end_column": 7,
+              "end_line": 83,
+              "file": 1
+            },
+            "value": {"sig_name":"reset"},
+            "type_name": "logic",
+            "source_lang_type_info": {
+              "type_name": "IO[Bool]"
+            }
+          },
+          {
+            "var_name": "vec1",
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 84,
+              "end_column": 16,
+              "end_line": 84,
+              "file": 1
+            },
+            "value": {"opcode":"'{","operands":[{"opcode":"'{","operands":[{"sig_name":"vec1_0_x_0"}]},{"opcode":"'{","operands":[{"sig_name":"vec1_1_x_0"}]}]},
+            "type_name": "Issue10_vec1_0",
+            "unpacked_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[VecType1[2]]"
+            }
+          },
+          {
+            "var_name": "vec2",
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 85,
+              "end_column": 16,
+              "end_line": 85,
+              "file": 1
+            },
+            "value": {"opcode":"'{","operands":[{"opcode":"'{","operands":[{"sig_name":"vec2_0_x_0"},{"sig_name":"vec2_0_y_0"}]},{"opcode":"'{","operands":[{"sig_name":"vec2_1_x_0"},{"sig_name":"vec2_1_y_0"}]}]},
+            "type_name": "Issue10_vec2_0",
+            "unpacked_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[VecType2[2]]"
+            }
+          },
+          {
+            "var_name": "vec3",
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 86,
+              "end_column": 16,
+              "end_line": 86,
+              "file": 1
+            },
+            "value": {"opcode":"'{","operands":[{"opcode":"'{","operands":[{"sig_name":"vec3_0_x_0"},{"sig_name":"vec3_0_y_0"},{"sig_name":"vec3_0_z_0"}]},{"opcode":"'{","operands":[{"sig_name":"vec3_1_x_0"},{"sig_name":"vec3_1_y_0"},{"sig_name":"vec3_1_z_0"}]}]},
+            "type_name": "Issue10_vec3_0",
+            "unpacked_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[VecType3[2]]"
+            }
+          },
+          {
+            "var_name": "vec4",
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 87,
+              "end_column": 16,
+              "end_line": 87,
+              "file": 1
+            },
+            "value": {"opcode":"'{","operands":[{"opcode":"'{","operands":[{"sig_name":"vec4_0_x_0"},{"sig_name":"vec4_0_y_0"},{"sig_name":"vec4_0_z_0"},{"sig_name":"vec4_0_w_0"}]},{"opcode":"'{","operands":[{"sig_name":"vec4_1_x_0"},{"sig_name":"vec4_1_y_0"},{"sig_name":"vec4_1_z_0"},{"sig_name":"vec4_1_w_0"}]}]},
+            "type_name": "Issue10_vec4_0",
+            "unpacked_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[VecType4[2]]"
+            }
+          },
+          {
+            "var_name": "vec5",
+            "hgl_loc": {
+              "begin_column": 16,
+              "begin_line": 88,
+              "end_column": 16,
+              "end_line": 88,
+              "file": 1
+            },
+            "value": {"opcode":"'{","operands":[{"opcode":"'{","operands":[{"sig_name":"vec5_0_x_0"},{"opcode":"'{","operands":[{"sig_name":"vec5_0_y_a_0"},{"sig_name":"vec5_0_y_b_0"},{"sig_name":"vec5_0_y_c_0"}]}]},{"opcode":"'{","operands":[{"sig_name":"vec5_1_x_0"},{"opcode":"'{","operands":[{"sig_name":"vec5_1_y_a_0"},{"sig_name":"vec5_1_y_b_0"},{"sig_name":"vec5_1_y_c_0"}]}]}]},
+            "type_name": "Issue10_vec5_0",
+            "unpacked_range": [
+              1,
+              0
+            ],
+            "source_lang_type_info": {
+              "type_name": "IO[VecType5[2]]"
+            }
+          }
+        ],
+        "children": []
+      }
+    ]
+  }
+  

--- a/tests/tyvcd.rs
+++ b/tests/tyvcd.rs
@@ -19,7 +19,7 @@ use pretty_assertions::assert_eq;
 #[test_case("tests/inputs/gcd.dd", 1; "Test gcd.dd")]
 #[test_case("tests/inputs/hgldd/global.dd", 1; "Test global.dd")]
 #[test_case("tests/inputs/hgldd", 7; "Test directory project")]
-
+#[test_case("tests/inputs/tyvcd/vecTest.dd", 1; "Test Index out of bounds in builder.rs")]
 fn test_hgldd_tyvcd_builder_success(file_path: &str, exp_hgldd_len: usize) {
     // Read the hgldd file
     let hgldd_file = Path::new(file_path);
@@ -42,6 +42,7 @@ fn test_hgldd_tyvcd_builder_success(file_path: &str, exp_hgldd_len: usize) {
 #[test_case("tests/inputs/tyvcd/foo/bar.dd", bar::create_bar_single; "Test bar.dd")]
 #[test_case("tests/inputs/tyvcd/foo", foo::create_foo; "Test directory foo")]
 #[test_case("tests/inputs/tyvcd/withBundlesAndVecs.dd", with_bundles_and_vecs::create_with_bundles_and_vecs; "Test with bundles and vecs")]
+#[test_case("tests/inputs/tyvcd/vecTest.dd", vec_test::create_vecs; "Test Index out of bounds in builder.rs")]
 fn test_tyvcd_single_file_assertions(
     file_path: &str,
     create_expected_output: fn() -> tyvcd::spec::TyVcd,


### PR DESCRIPTION
The build method in TyVcdBuilder wasn't getting the kind of a vector properly. The previous tests were working for a coincidence, indeed the issue occurs only when a vector of bundle is used and its type contains more than 2 fields (n_fields > 2). But now, that test case is covered and the issue is solved.

Fixes #10 