### PR TITLE
Improve `create_val_repr`. An external value render function can now be used to render values in TyVcd

### DIFF
--- a/src/tyvcd/spec.rs
+++ b/src/tyvcd/spec.rs
@@ -248,40 +248,41 @@ impl Variable {
     }
 
     #[deprecated = "Should be removed. A better version from trace value should be used instead"]
-    pub fn create_val_repr(&self, raw_val_vcd: &str) -> String {
-        let size = self.kind.find_width() as usize;
-
-        if raw_val_vcd.len() < size {
-            return String::from("---");
-        }
+    pub fn create_val_repr(
+        &self,
+        raw_val_vcd: &str,
+        render_fn: &dyn Fn(u64, &str) -> String,
+    ) -> String {
+        // let size = self.kind.find_width() as usize;
+        // if raw_val_vcd.len() < size {
+        //     return String::from("---");
+        // }
 
         match &self.kind {
-            VariableKind::Ground(width) => {
-                if *width <= 1 {
-                    raw_val_vcd.to_string()
-                } else {
-                    format!(
-                        "{} {}: {raw_val_vcd}",
-                        &self.high_level_info.type_name, &self.name
-                    )
-                }
-            }
-
+            // If the variable is a ground type: use the raw value directly
+            VariableKind::Ground(width) => render_fn(*width as u64, raw_val_vcd),
+            // Otherwise, encode the fields recursively {x, {y, z}} or [x, y, z]
             VariableKind::Vector { fields } | VariableKind::Struct { fields } => {
                 // Encode the fields recursively {x, {y, z}} or [x, y, z]
                 let (lb, sep, rb) = match &self.kind {
-                    VariableKind::Vector { .. } => ("[", ", ", ']'),
-                    VariableKind::Struct { .. } => ("{", ", ", '}'),
+                    VariableKind::Vector { .. } => ('[', ", ", ']'),
+                    VariableKind::Struct { .. } => ('{', ", ", '}'),
                     _ => unreachable!(),
                 };
 
-                let mut value =
-                    format!("{} {}: {}", &self.high_level_info.type_name, &self.name, lb);
-
+                // Build the value of the aggregate type
+                let mut value = lb.to_string();
                 let mut start_idx = 0;
+
                 for field in fields {
                     let end_idx = start_idx + field.kind.find_width() as usize;
-                    value.push_str(&field.create_val_repr(&raw_val_vcd[start_idx..end_idx]));
+                    let field_str = format!(
+                        "{}: {}",
+                        field.name,
+                        field.create_val_repr(&raw_val_vcd[start_idx..end_idx], render_fn)
+                    );
+
+                    value.push_str(&field_str);
                     value.push_str(sep);
                     start_idx = end_idx;
                 }


### PR DESCRIPTION
Improve #17 